### PR TITLE
[16.0][IMP] edi_storage_oca: raise error when retrieving an empty file

### DIFF
--- a/edi_storage_oca/components/base.py
+++ b/edi_storage_oca/components/base.py
@@ -67,7 +67,11 @@ class EDIStorageComponentMixin(AbstractComponent):
             # TODO: support match via pattern (eg: filename-prefix-*)
             # otherwise is impossible to retrieve input files and acks
             # (the date will never match)
-            return utils.get_file(self.storage, path.as_posix(), binary=binary)
+            data = utils.get_file(self.storage, path.as_posix(), binary=binary)
+            if not data:
+                raise ValueError("The file is empty to be retrieved")
+            return data
+
         except FileNotFoundError:
             _logger.info(
                 "Ignored FileNotFoundError when trying "


### PR DESCRIPTION
![image](https://github.com/QuocDuong1306/edi-framework/assets/127363167/3914479e-52da-4c8b-8227-23ef2a6445eb)
