### PR TITLE
[IMP] edi_oca: provide an option to allow or not allow receive empty files on type

### DIFF
--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -181,6 +181,9 @@ class EDIExchangeType(models.Model):
         ],
         help="Handling of decoding errors on process (default is always 'Raise Error').",
     )
+    allow_empty_files_on_receive = fields.Boolean(
+        string="Allow Empty Files on Receive", default=False
+    )
 
     _sql_constraints = [
         (

--- a/edi_oca/tests/test_backend_input.py
+++ b/edi_oca/tests/test_backend_input.py
@@ -43,3 +43,26 @@ class EDIBackendTestInputCase(EDIBackendCommonComponentRegistryTestCase):
         self.backend.with_context(fake_output="yeah!").exchange_receive(self.record)
         self.assertEqual(self.record._get_file_content(), "yeah!")
         self.assertRecordValues(self.record, [{"edi_exchange_state": "input_received"}])
+
+    def test_receive_no_allow_empty_file_record(self):
+        self.record.edi_exchange_state = "input_pending"
+        self.backend.with_context(
+            fake_output="", _edi_receive_break_on_error=False
+        ).exchange_receive(self.record)
+        # Check the record
+        msg = "File is Empty and Empty Files are not allowed for this exchange type"
+        self.assertIn(msg, self.record.exchange_error)
+        self.assertEqual(self.record._get_file_content(), "")
+        self.assertRecordValues(
+            self.record, [{"edi_exchange_state": "input_receive_error"}]
+        )
+
+    def test_receive_allow_empty_file_record(self):
+        self.record.edi_exchange_state = "input_pending"
+        self.record.type_id.allow_empty_files_on_receive = True
+        self.backend.with_context(
+            fake_output="", _edi_receive_break_on_error=False
+        ).exchange_receive(self.record)
+        # Check the record
+        self.assertEqual(self.record._get_file_content(), "")
+        self.assertRecordValues(self.record, [{"edi_exchange_state": "input_received"}])

--- a/edi_oca/tests/test_backend_process.py
+++ b/edi_oca/tests/test_backend_process.py
@@ -67,8 +67,17 @@ class EDIBackendTestProcessCase(EDIBackendCommonComponentRegistryTestCase):
     def test_process_no_file_record(self):
         self.record.write({"edi_exchange_state": "input_received"})
         self.record.exchange_file = False
+        self.exchange_type_in.allow_empty_files_on_receive = False
         with self.assertRaises(UserError):
             self.record.action_exchange_process()
+
+    @mute_logger("odoo.models.unlink")
+    def test_process_allow_no_file_record(self):
+        self.record.write({"edi_exchange_state": "input_received"})
+        self.record.exchange_file = False
+        self.exchange_type_in.allow_empty_files_on_receive = True
+        self.record.action_exchange_process()
+        self.assertEqual(self.record.edi_exchange_state, "input_processed")
 
     def test_process_outbound_record(self):
         vals = {

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -58,6 +58,10 @@
                                 name="encoding_in_error_handler"
                                 attrs="{'invisible': [('direction', '=', 'output')]}"
                             />
+                            <field
+                                name="allow_empty_files_on_receive"
+                                attrs="{'invisible': [('direction', '=', 'output')]}"
+                            />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Requirements:

- add a new boolean field on edi.exchange.type, after "Decoding Error Handler" on form view: Allow empty files (default: False)
- check content if not None but empty here: https://github.com/camptocamp/edi-framework/blob/0d4b9bdd1b180b06e0eab7b61aeee4d7bc3dc40e/edi_oca/models/edi_backend.py#L533
- raise the ValueError there: "File is empty and empty files are not allowed for this exchange type"

Context:
- For now, when we receive the empty file:
  - Receive step will not be `error_on_receive` , just ignore the content if return values in (None, ""): [here](https://github.com/OCA/edi-framework/blob/77184146551ea042190ca7b0a1c290f848dd202f/edi_oca/models/edi_backend.py#L530)
  - But the [process step will raise the error](https://github.com/OCA/edi-framework/blob/77184146551ea042190ca7b0a1c290f848dd202f/edi_oca/models/edi_backend.py#L460) if not having file
- This PR goal is to improve the handling of empty files
- By default, we consider that an empty file is an error case --> to avoid annoying in queue job
- But there might be some people using the framework in cases where an empty file is a legit case (e.g. daily SO csv file, without any header: empty just means that there was no sale), which is why we introduce a boolean to enable it
  
