### PR TITLE
[16.0][IMP] edi_storage_oca: Add script to migrate to v16

### DIFF
--- a/edi_storage_oca/migrations/16.0.1.0.0/pre-migrate.py
+++ b/edi_storage_oca/migrations/16.0.1.0.0/pre-migrate.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+from odoo.tools.sql import column_exists, create_column, rename_column
+
+from odoo.addons.http_routing.models.ir_http import slugify
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    required_modules = ("storage_backend", "edi_storage_oca")
+    if not env["ir.module.module"].search(
+        [("name", "in", required_modules), ("state", "=", "installed")]
+    ):
+        return
+    if not column_exists(cr, "edi_backend", "new_storage_id"):
+        create_column(cr, "edi_backend", "new_storage_id", "int4")
+    _create_fs_storage_records(env)
+    if column_exists(cr, "edi_backend", "new_storage_id"):
+        rename_column(cr, "edi_backend", "storage_id", "old_storage_id")
+        rename_column(cr, "edi_backend", "new_storage_id", "storage_id")
+
+
+def _create_fs_storage_records(env):
+    # Create a fs.storage record for each backend.storage
+    storage_backend_records = env["storage.backend"].search([])
+    if not storage_backend_records:
+        return
+
+    # make sure all backend_type can be mapped even if corresponding modules
+    # have not been migrated (on purpose because we should switch to fs_storage)
+    selection = [
+        ("filesystem", "Filesystem"),
+        ("ftp", "FTP"),
+        ("sftp", "SFTP"),
+        ("s3", "S3"),
+    ]
+    env["storage.backend"]._fields["backend_type"].selection = selection
+    env["storage.backend"]._fields["backend_type_env_default"].selection = selection
+
+    fs_storage = env["fs.storage"]
+    for record in storage_backend_records:
+        protocol = "file"
+        if record.backend_type == "ftp":
+            protocol = "ftp"
+        elif record.backend_type == "sftp":
+            protocol = "sftp"
+        elif record.backend_type == "s3":
+            protocol = "s3"
+
+        code = slugify(record.name).replace("-", "_")
+        if fs_storage.search([("code", "=", code)]):
+            code = "%s_%d" % (code, record.id)
+
+        res_id = fs_storage.create(
+            {
+                "name": record.name,
+                "code": code,
+                "protocol": protocol,
+                "directory_path": record.directory_path,
+            }
+        )
+
+        env.cr.execute(
+            "UPDATE edi_backend SET new_storage_id = %s WHERE storage_id = %s",
+            (res_id.id, record.id),
+        )


### PR DESCRIPTION
### Context:
- Assume that `storage_backend` will still be installed in the old db and that we simply have to create the matching `fs.storage` records w/ their conf leaving the old storage.backend records untouched.

### Notes:
- Put this script to `16.0.1.0.0` because of changing storage_backend to fs_storage, if we put it to the later versions, the storages in backends have been changed, so can't link to the mapping records in `fs.storage`
- Implemented solutions in here:
   - Create mapping records in `pre-migration` step
   - Export all backends with their backend.storage to `data.txt`
   - After that, in `post-migration` step, will read data from `data.txt` and link the backends to the mapping records in fs.storage