### PR TITLE
[16.0][IMP] edi_oca: remove deprecated job functions

### DIFF
--- a/edi_oca/data/job_function.xml
+++ b/edi_oca/data/job_function.xml
@@ -24,25 +24,4 @@
         <field name="method">exchange_create_ack_record</field>
         <field name="channel_id" ref="channel_edi_exchange" />
     </record>
-    <!-- TO be removed on 16.0 -->
-    <record id="job_edi_backend_record_generate" model="queue.job.function">
-        <field name="model_id" ref="model_edi_backend" />
-        <field name="method">exchange_generate</field>
-        <field name="channel_id" ref="channel_edi_exchange" />
-    </record>
-    <record id="job_edi_backend_record_send" model="queue.job.function">
-        <field name="model_id" ref="model_edi_backend" />
-        <field name="method">exchange_send</field>
-        <field name="channel_id" ref="channel_edi_exchange" />
-    </record>
-    <record id="job_edi_backend_record_receive" model="queue.job.function">
-        <field name="model_id" ref="model_edi_backend" />
-        <field name="method">exchange_receive</field>
-        <field name="channel_id" ref="channel_edi_exchange" />
-    </record>
-    <record id="job_edi_backend_record_process" model="queue.job.function">
-        <field name="model_id" ref="model_edi_backend" />
-        <field name="method">exchange_process</field>
-        <field name="channel_id" ref="channel_edi_exchange" />
-    </record>
 </odoo>

--- a/edi_oca/tests/__init__.py
+++ b/edi_oca/tests/__init__.py
@@ -3,7 +3,6 @@ from . import test_exchange_type
 from . import test_record
 from . import test_component_match
 from . import test_backend_base
-from . import test_backend_jobs
 from . import test_backend_output
 from . import test_backend_input
 from . import test_backend_process
@@ -12,4 +11,5 @@ from . import test_consumer_mixin
 from . import test_edi_backend_cron
 from . import test_security
 from . import test_quick_exec
+from . import test_exchange_record_jobs
 from . import test_exchange_type_encoding


### PR DESCRIPTION
TODO from:
- https://github.com/OCA/edi-framework/commit/452b75b42ef3948fc2efaf02bc7ed296cef53408